### PR TITLE
Update docs with new earmuffed *use-ansi*.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Wrap strings in ANSI color and style codes like this:
 
 
 You can turn the production of ANSI codes on or off by rebinding the
-`clansi.core/use-ansi` variable at runtime. This allows you to
+`clansi.core/*use-ansi*` variable at runtime. This allows you to
 maintain only one version of your code with the strings marked up for
 color, and then turn ANSI on or off as desired, according to the
 properties of each output device, user preference, execution context,


### PR DESCRIPTION
I adjusted the README to reflect the new earmuffed name.
